### PR TITLE
feat: coffin-taper logo, dark-only theme, compact homepage

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,10 +7,19 @@ export default defineConfig({
 	site: 'https://docs.racku.la',
 	integrations: [
 		starlight({
-			title: 'Rackula Docs',
+			// Site title is the header label and the tab-title suffix — Starlight
+			// renders `<page title> | <site title>`. The homepage page title is
+			// "Rackula" (src/content/docs/index.mdx), so the landing tab reads
+			// "Rackula | Documentation".
+			title: 'Documentation',
 			logo: {
 				light: './src/assets/logo-light.svg',
 				dark: './src/assets/logo-dark.svg',
+			},
+			// Dark-only site: force the Dracula theme and remove the switcher.
+			components: {
+				ThemeProvider: './src/components/ThemeProvider.astro',
+				ThemeSelect: './src/components/ThemeSelect.astro',
 			},
 			social: [
 				{ icon: 'github', label: 'GitHub', href: 'https://github.com/RackulaLives/Rackula' },
@@ -39,6 +48,12 @@ export default defineConfig({
 			],
 			customCss: ['./src/styles/dracula.css'],
 			head: [
+				// Dark-only: declare the colour scheme so native UI stays dark and
+				// dark-theme detectors (e.g. Dark Reader) don't re-invert the site.
+				{
+					tag: 'meta',
+					attrs: { name: 'color-scheme', content: 'dark' },
+				},
 				// Preconnect to Google Fonts for faster loading
 				{
 					tag: 'link',

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg viewBox="0 0 36 54" xmlns="http://www.w3.org/2000/svg">
-  <!-- Rackula Favicon - v2 Widow's Peak Mark -->
+<svg viewBox="-12 0 80 80" xmlns="http://www.w3.org/2000/svg">
+  <!-- Rackula coffin-taper favicon. Slots punched out; fill adapts to OS colour scheme. -->
   <style>
-    .frame { fill: #BD93F9; }
-    .slot { fill: #282A36; }
+    .mark { fill: #BD93F9; }
     @media (prefers-color-scheme: light) {
-      .frame { fill: #644AC9; }
-      .slot { fill: #FFFBEB; }
+      .mark { fill: #644AC9; }
     }
   </style>
-  <path class="frame" d="M0 0 L14 0 L18 6 L22 0 L36 0 L36 54 L0 54 Z"/>
-  <rect class="slot" x="5" y="10" width="26" height="10"/>
-  <rect class="slot" x="5" y="22" width="26" height="10"/>
-  <rect class="slot" x="5" y="34" width="26" height="10"/>
+  <path class="mark" fill-rule="evenodd" d="M1.5 0Q0 0 0 1.5L0 16.5L2.6 77.5Q2.6 80 5.1 80L50.9 80Q53.4 80 53.4 77.5L56 16.5L56 1.5Q56 0 54.5 0L39.5 0Q38.2 0 37 2.6L28 17.8L19 2.6Q17.8 0 16.5 0ZM7.6 21.5h40.8q2 0 2 2v9q0 2 -2 2h-40.8q-2 0 -2 -2v-9q0 -2 2 -2ZM9.4 40.5h37.2q2 0 2 2v9q0 2 -2 2h-37.2q-2 0 -2 -2v-9q0 -2 2 -2ZM11.2 59.5h33.6q2 0 2 2v9q0 2 -2 2h-33.6q-2 0 -2 -2v-9q0 -2 2 -2Z"/>
 </svg>

--- a/src/assets/logo-dark.svg
+++ b/src/assets/logo-dark.svg
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg viewBox="0 0 36 54" xmlns="http://www.w3.org/2000/svg">
-  <!-- Rackula Logo v2 - Widow's Peak Mark (Dark Mode) -->
-  <path d="M0 0 L14 0 L18 6 L22 0 L36 0 L36 54 L0 54 Z" fill="#BD93F9"/>
-  <rect x="5" y="10" width="26" height="10" fill="#282A36"/>
-  <rect x="5" y="22" width="26" height="10" fill="#282A36"/>
-  <rect x="5" y="34" width="26" height="10" fill="#282A36"/>
+<svg viewBox="0 0 56 80" xmlns="http://www.w3.org/2000/svg">
+  <!-- Rackula coffin-taper mark (dark mode). Slots punched out (fill-rule evenodd). -->
+  <path fill="#BD93F9" fill-rule="evenodd" d="M1.5 0Q0 0 0 1.5L0 16.5L2.6 77.5Q2.6 80 5.1 80L50.9 80Q53.4 80 53.4 77.5L56 16.5L56 1.5Q56 0 54.5 0L39.5 0Q38.2 0 37 2.6L28 17.8L19 2.6Q17.8 0 16.5 0ZM7.6 21.5h40.8q2 0 2 2v9q0 2 -2 2h-40.8q-2 0 -2 -2v-9q0 -2 2 -2ZM9.4 40.5h37.2q2 0 2 2v9q0 2 -2 2h-37.2q-2 0 -2 -2v-9q0 -2 2 -2ZM11.2 59.5h33.6q2 0 2 2v9q0 2 -2 2h-33.6q-2 0 -2 -2v-9q0 -2 2 -2Z"/>
 </svg>

--- a/src/assets/logo-light.svg
+++ b/src/assets/logo-light.svg
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg viewBox="0 0 36 54" xmlns="http://www.w3.org/2000/svg">
-  <!-- Rackula Logo v2 - Widow's Peak Mark (Light Mode) -->
-  <path d="M0 0 L14 0 L18 6 L22 0 L36 0 L36 54 L0 54 Z" fill="#644AC9"/>
-  <rect x="5" y="10" width="26" height="10" fill="#FFFBEB"/>
-  <rect x="5" y="22" width="26" height="10" fill="#FFFBEB"/>
-  <rect x="5" y="34" width="26" height="10" fill="#FFFBEB"/>
+<svg viewBox="0 0 56 80" xmlns="http://www.w3.org/2000/svg">
+  <!-- Rackula coffin-taper mark (light mode). Slots punched out (fill-rule evenodd). -->
+  <path fill="#644AC9" fill-rule="evenodd" d="M1.5 0Q0 0 0 1.5L0 16.5L2.6 77.5Q2.6 80 5.1 80L50.9 80Q53.4 80 53.4 77.5L56 16.5L56 1.5Q56 0 54.5 0L39.5 0Q38.2 0 37 2.6L28 17.8L19 2.6Q17.8 0 16.5 0ZM7.6 21.5h40.8q2 0 2 2v9q0 2 -2 2h-40.8q-2 0 -2 -2v-9q0 -2 2 -2ZM9.4 40.5h37.2q2 0 2 2v9q0 2 -2 2h-37.2q-2 0 -2 -2v-9q0 -2 2 -2ZM11.2 59.5h33.6q2 0 2 2v9q0 2 -2 2h-33.6q-2 0 -2 -2v-9q0 -2 2 -2Z"/>
 </svg>

--- a/src/components/ThemeProvider.astro
+++ b/src/components/ThemeProvider.astro
@@ -1,0 +1,15 @@
+---
+/**
+ * ThemeProvider override — dark-only site.
+ *
+ * Replaces Starlight's default provider (which reads system preference /
+ * localStorage). We force the Dracula dark theme unconditionally and stub the
+ * picker hook so nothing errors now that the theme switcher is removed.
+ */
+---
+
+{/* Inlined to avoid FOUC. */}
+<script is:inline>
+	document.documentElement.dataset.theme = 'dark';
+	window.StarlightThemeProvider = { updatePickers() {} };
+</script>

--- a/src/components/ThemeSelect.astro
+++ b/src/components/ThemeSelect.astro
@@ -1,0 +1,8 @@
+---
+/**
+ * ThemeSelect override — dark-only site.
+ *
+ * Renders nothing: the light/dark switcher is intentionally removed. Dark is
+ * forced in ThemeProvider.astro.
+ */
+---

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -5,8 +5,6 @@ template: splash
 hero:
   title: Rackula Documentation
   tagline: Documentation for the FOSS rack layout designer.
-  image:
-    file: ../../assets/logo-dark.svg
   actions:
     - text: Get Started
       link: /getting-started/

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,8 +1,9 @@
 ---
-title: Rackula Documentation
+title: Rackula
 description: Documentation for Rackula, a FOSS rack layout designer for homelabbers.
 template: splash
 hero:
+  title: Rackula Documentation
   tagline: Documentation for the FOSS rack layout designer.
   image:
     file: ../../assets/logo-dark.svg

--- a/src/styles/dracula.css
+++ b/src/styles/dracula.css
@@ -15,6 +15,10 @@
    ============================================ */
 
 :root {
+  /* Dark-only site — keep native controls/scrollbars dark and signal
+     dark-theme detectors (e.g. Dark Reader) not to re-invert. */
+  color-scheme: dark;
+
   /* Backgrounds */
   --sl-color-bg: #282A36;
   --sl-color-bg-nav: #21222C;
@@ -60,48 +64,6 @@
 }
 
 /* ============================================
-   Alucard (Light Mode)
-   ============================================ */
-
-:root[data-theme='light'] {
-  /* Backgrounds - warm cream tones */
-  --sl-color-bg: #FFFBEB;
-  --sl-color-bg-nav: #EFEDDC;
-  --sl-color-bg-sidebar: #EFEDDC;
-  --sl-color-bg-inline-code: #DEDCCF;
-
-  /* Text */
-  --sl-color-text: #1F1F1F;
-  --sl-color-text-accent: #644AC9;
-
-  /* Accent colours */
-  --sl-color-accent: #644AC9;
-  --sl-color-accent-low: rgba(100, 74, 201, 0.15);
-  --sl-color-accent-high: #644AC9;
-
-  /* Grays for light mode */
-  --sl-color-white: #FFFBEB;
-  --sl-color-gray-1: #1F1F1F;
-  --sl-color-gray-2: #3A3A3A;
-  --sl-color-gray-3: #5A5A5A;
-  --sl-color-gray-4: #6C664B;
-  --sl-color-gray-5: #CFCFDE;
-  --sl-color-gray-6: #DEDCCF;
-  --sl-color-black: #1F1F1F;
-
-  /* Semantic colours - darker for light background contrast */
-  --sl-color-green: #14710A;
-  --sl-color-orange: #A34D14;
-  --sl-color-red: #CB3A2A;
-  --sl-color-blue: #036A96;
-  --sl-color-purple: #644AC9;
-
-  /* Hairline/borders */
-  --sl-color-hairline: #CFCFDE;
-  --sl-color-hairline-light: #DEDCCF;
-}
-
-/* ============================================
    Typography Overrides
    ============================================ */
 
@@ -138,10 +100,6 @@ a {
 
 a:hover {
   color: #8BE9FD; /* Cyan on hover (Dracula) */
-}
-
-:root[data-theme='light'] a:hover {
-  color: #036A96; /* Alucard cyan */
 }
 
 /* ============================================
@@ -186,32 +144,24 @@ nav.sidebar a[aria-current="page"] {
    Button Styling
    ============================================ */
 
-.action.primary {
+/* Starlight 0.41 renders hero actions as .sl-link-button (was .action). */
+.sl-link-button.primary {
   background: #8BE9FD; /* Cyan CTA */
   color: #282A36;
   border: none;
 }
 
-.action.primary:hover {
+.sl-link-button.primary:hover {
   background: #50FA7B; /* Green on hover */
 }
 
-:root[data-theme='light'] .action.primary {
-  background: #036A96;
-  color: #FFFBEB;
-}
-
-:root[data-theme='light'] .action.primary:hover {
-  background: #14710A;
-}
-
 /* Secondary/minimal buttons */
-.action.minimal {
+.sl-link-button.minimal {
   color: var(--sl-color-accent);
   border-color: var(--sl-color-accent);
 }
 
-.action.minimal:hover {
+.sl-link-button.minimal:hover {
   background: var(--sl-color-accent-low);
 }
 


### PR DESCRIPTION
Brings the docs site in line with the marketing site (www).

## Changes

**Logo → coffin taper**
- Header logos (`logo-dark` #BD93F9, `logo-light` #644AC9) and `favicon.svg` rebuilt with the canonical coffin-taper mark, `fill-rule="evenodd"` punch-through so slots adapt to any background.

**Title → "Rackula | Documentation"**
- Site title → `Documentation`; homepage page title → `Rackula`, so the landing tab reads `Rackula | Documentation` and content pages read `<Page> | Documentation`.

**Dark-only**
- Force the Dracula theme (`ThemeProvider` override) and remove the theme switcher (empty `ThemeSelect` override).
- Drop the Alucard light palette + light overrides from `dracula.css`; declare `color-scheme: dark` (CSS + meta) so native UI stays dark and dark-theme detectors (Dark Reader) don't re-invert.
- Fix the hero CTA: Starlight 0.41 renders `.sl-link-button` (was `.action`), so the primary "Get Started" button styles apply again (was invisible purple-on-purple).

**Compact homepage**
- Drop the oversized splash `hero.image` so the landing opens with the title, tagline, and CTAs — content cards visible immediately instead of below the fold.

## Verification
- `npm run build` passes; previewed desktop + mobile
- Dark holds even with OS set to light; switcher gone; CTA visible; tab titles correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)